### PR TITLE
Use username if Slack display name is empty

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -83,7 +83,7 @@ class Dispatcher(object):
                 limit = int(stripped_command_body)
                 if limit <= 1:
                     return post_message(
-                        'That is quite selfish %s. You have to choose a number greater than 1!' % self.request_user.first_name,
+                        'That is quite selfish %s. You have to choose a number greater than 1!' % self.request_user.display_name,
                         self.channel
                     )
             except ValueError:
@@ -96,7 +96,7 @@ class Dispatcher(object):
         return post_message(
             random.choice([
                 '%s is making %s tea, who is in?' % (
-                    self.request_user.first_name,
+                    self.request_user.display_name,
                     '' if limit is None else '%s cups of' % limit
                 ),
                 'Who wants a cuppa?'
@@ -120,27 +120,27 @@ class Dispatcher(object):
     def me(self):
         server = self.session.query(Server).filter_by(completed=False)
         if not server.count():
-            return post_message('No one has volunteered to make tea, why dont you make it %s?' % self.request_user.first_name, self.channel)
+            return post_message('No one has volunteered to make tea, why dont you make it %s?' % self.request_user.display_name, self.channel)
 
         server = server.first()
 
         if server.user_id == self.request_user.id:
             return post_message(
-                '%s you are making tea! :face_with_rolling_eyes:' % self.request_user.first_name, self.channel
+                '%s you are making tea! :face_with_rolling_eyes:' % self.request_user.display_name, self.channel
             )
 
         if self.session.query(Customer).filter_by(user_id=self.request_user.id, server_id=server.id).count():
-            return post_message('You said it once already %s.' % self.request_user.first_name, self.channel)
+            return post_message('You said it once already %s.' % self.request_user.display_name, self.channel)
 
         if server.limit and self.session.query(Customer).filter_by(server_id=server.id).count() >= server.limit:
             return post_message(
-                'I am sorry %s but %s will only brew %s cups' % (self.request_user.first_name, server.user.first_name, server.limit),
+                'I am sorry %s but %s will only brew %s cups' % (self.request_user.display_name, server.user.display_name, server.limit),
                 self.channel
             )
 
         self.session.add(Customer(user_id=self.request_user.id, server_id=server.id))
         self.session.commit()
-        return post_message('Hang tight %s, tea is being served soon' % self.request_user.first_name, self.channel)
+        return post_message('Hang tight %s, tea is being served soon' % self.request_user.display_name, self.channel)
 
     @require_registration
     def nominate(self):
@@ -174,8 +174,8 @@ class Dispatcher(object):
 
         return post_message(
             '%s has nominated %s to make tea! Who wants in?' % (
-                self.request_user.first_name,
-                nominated_user.first_name
+                self.request_user.display_name,
+                nominated_user.display_name
             ),
             self.channel,
             gif_search_phrase='celebrate'
@@ -229,7 +229,7 @@ class Dispatcher(object):
         if not self.command_body:
             return post_message('You didn\'t tell me what type of tea you like. Try typing `@teabot register green tea`', self.channel)
 
-        message = 'Welcome to the tea party %s' % self.request_user.first_name
+        message = 'Welcome to the tea party %s' % self.request_user.display_name
         if self.request_user.tea_type:
             message = 'I have updated your tea preference.'
 

--- a/src/models.py
+++ b/src/models.py
@@ -33,6 +33,10 @@ class User(Base):
     teas_received = Column(Integer, nullable=False, default=0)
     times_brewed = Column(Integer, nullable=False, default=0)
 
+    @property
+    def display_name(self):
+        return self.first_name or self.username
+
 
 class Server(Base):
     __tablename__ = 'server'

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -53,7 +53,7 @@ def _brew_countdown(channel):
 
     return post_message("\n".join(
         ['Time is up!'] +
-        ['%s wants %s' % (customer.user.first_name, customer.user.tea_type) for customer in customers]
+        ['%s wants %s' % (customer.user.display_name, customer.user.tea_type) for customer in customers]
     ), channel)
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -119,7 +119,7 @@ class DispatcherTestCase(BaseTestCase):
             'user': self.registered_user.slack_id
         }])
         self.mock_post_message.assert_called_with(
-            'Hang tight %s, tea is being served soon' % self.registered_user.first_name,
+            'Hang tight %s, tea is being served soon' % self.registered_user.display_name,
             'tearoom'
         )
         self.assertIsNotNone(CustomerManager.get_for_user_server(self.registered_user.id, server.id))
@@ -140,7 +140,7 @@ class DispatcherTestCase(BaseTestCase):
             'user': self.registered_user.slack_id
         }])
         self.mock_post_message.assert_called_with(
-            'No one has volunteered to make tea, why dont you make it %s?' % self.registered_user.first_name,
+            'No one has volunteered to make tea, why dont you make it %s?' % self.registered_user.display_name,
             'tearoom'
         )
         self.assertEqual(self.session.query(Customer).filter_by(user_id=self.registered_user.id).count(), 0)
@@ -154,7 +154,7 @@ class DispatcherTestCase(BaseTestCase):
             'user': self.registered_user.slack_id
         }])
         self.mock_post_message.assert_called_with(
-            '%s you are making tea! :face_with_rolling_eyes:' % self.registered_user.first_name,
+            '%s you are making tea! :face_with_rolling_eyes:' % self.registered_user.display_name,
             'tearoom'
         )
         self.assertIsNone(CustomerManager.get_for_user_server(self.registered_user.id, server.id))
@@ -168,7 +168,7 @@ class DispatcherTestCase(BaseTestCase):
             'user': self.registered_user.slack_id
         }])
         self.mock_post_message.assert_called_with(
-            'Hang tight %s, tea is being served soon' % self.registered_user.first_name,
+            'Hang tight %s, tea is being served soon' % self.registered_user.display_name,
             'tearoom'
         )
         self.assertIsNotNone(CustomerManager.get_for_user_server(self.registered_user.id, server.id))
@@ -186,7 +186,7 @@ class DispatcherTestCase(BaseTestCase):
             'user': self.registered_user.slack_id
         }])
         self.mock_post_message.assert_called_with(
-            'I am sorry %s but %s will only brew 2 cups' % (self.registered_user.first_name, user1.first_name),
+            'I am sorry %s but %s will only brew 2 cups' % (self.registered_user.display_name, user1.display_name),
             'tearoom'
         )
         self.assertIsNone(CustomerManager.get_for_user_server(self.registered_user.id, server.id))
@@ -206,8 +206,8 @@ class DispatcherTestCase(BaseTestCase):
             }])
             self.mock_post_message.assert_any_call(
                 '%s has nominated %s to make tea! Who wants in?' % (
-                    self.registered_user.first_name,
-                    self.registered_user1.first_name
+                    self.registered_user.display_name,
+                    self.registered_user1.display_name
                 ),
                 'tearoom',
                 gif_search_phrase='celebrate'

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -48,7 +48,7 @@ class TasksTestCase(BaseTestCase):
         self.assertEqual(user1.times_brewed, 0)
         self.assertEqual(user1.nomination_points, 0)
         self.mock_post_message.assert_called_with(
-            'Time is up!\n%s wants %s' % (user1.first_name, user1.tea_type),
+            'Time is up!\n%s wants %s' % (user1.display_name, user1.tea_type),
             'tearoom'
         )
 


### PR DESCRIPTION
In cases where Slack users have not yet set their first and last names we should fallback to using their display name in messages.